### PR TITLE
fix compile failure, because the version of rules_foreign_cc not locked

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,8 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_foreign_cc",
-    strip_prefix = "rules_foreign_cc-master",
-    url = "https://github.com/bazelbuild/rules_foreign_cc/archive/master.zip",
+    sha256 = "c2cdcf55ffaf49366725639e45dedd449b8c3fe22b54e31625eb80ce3a240f1e",
+    strip_prefix = "rules_foreign_cc-0.1.0",
+    url = "https://github.com/bazelbuild/rules_foreign_cc/archive/0.1.0.zip",
 )
 
 load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")


### PR DESCRIPTION
lock the version of rules_foreign_cc to 0.1.0, because the version after 0.1.0 update loads of workspace_definitions.bzl to foreign_cc:repositories.bzl, which make compile failure.